### PR TITLE
Enhancement: support float values for heart rate

### DIFF
--- a/tcxparser.py
+++ b/tcxparser.py
@@ -14,7 +14,7 @@ class TCXParser:
         self.activity = self.root.Activities.Activity
 
     def hr_values(self):
-        return [int(x.text) for x in self.root.xpath('//ns:HeartRateBpm/ns:Value', namespaces={'ns': namespace})]
+        return [float(x.text) for x in self.root.xpath('//ns:HeartRateBpm/ns:Value', namespaces={'ns': namespace})]
 
     def altitude_points(self):
         return [float(x.text) for x in self.root.xpath('//ns:AltitudeMeters', namespaces={'ns': namespace})]


### PR DESCRIPTION
A .tcx file from mapmyrun stores the heart rate as floating point number, e.g. '88.0'. So far I've only seen integer values for heart rate in such files, but in any case this PR should be able to deal with both integer and non-integer values.