### PR TITLE
Add started_at, distance_values and position_values

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,5 +12,6 @@ Other contributions from:
 * Adam Neumann (@noizwaves)
 * Stephen Doyle (@stevedoyle)
 * Loïs Taulelle (@ltaulell)
+* Jan Pipek (@janpipek)
 
 Thank you!

--- a/tcxparser/tcxparser.py
+++ b/tcxparser/tcxparser.py
@@ -29,6 +29,9 @@ class TCXParser:
             float(pos.LongitudeDegrees.text))
             for pos in self.root.xpath('//ns:Trackpoint/ns:Position', namespaces={'ns': namespace})]
 
+    def distance_values(self):
+        return self.root.findall('.//ns:DistanceMeters', namespaces={'ns': namespace})
+
     def time_values(self):
         return [x.text for x in self.root.xpath('//ns:Time', namespaces={'ns': namespace})]
 
@@ -59,7 +62,7 @@ class TCXParser:
 
     @property
     def distance(self):
-        distance_values = self.root.findall('.//ns:DistanceMeters', namespaces={'ns': namespace})
+        distance_values = self.distance_values()
         return distance_values[-1] if distance_values else 0
 
     @property

--- a/tcxparser/tcxparser.py
+++ b/tcxparser/tcxparser.py
@@ -53,6 +53,10 @@ class TCXParser:
         return self.activity.attrib['Sport'].lower()
 
     @property
+    def started_at(self):
+        return self.activity.Lap[0].attrib["StartTime"]
+
+    @property
     def completed_at(self):
         return self.activity.Lap[-1].Track.Trackpoint[-1].Time.pyval
 

--- a/tcxparser/tcxparser.py
+++ b/tcxparser/tcxparser.py
@@ -30,7 +30,7 @@ class TCXParser:
             for pos in self.root.xpath('//ns:Trackpoint/ns:Position', namespaces={'ns': namespace})]
 
     def distance_values(self):
-        return self.root.findall('.//ns:DistanceMeters', namespaces={'ns': namespace})
+        return self.root.findall('.//ns:Trackpoint/ns:DistanceMeters', namespaces={'ns': namespace})
 
     def time_values(self):
         return [x.text for x in self.root.xpath('//ns:Time', namespaces={'ns': namespace})]

--- a/tcxparser/tcxparser.py
+++ b/tcxparser/tcxparser.py
@@ -23,6 +23,12 @@ class TCXParser:
     def altitude_points(self):
         return [float(x.text) for x in self.root.xpath('//ns:AltitudeMeters', namespaces={'ns': namespace})]
 
+    def position_values(self):
+        return [
+            (float(pos.LatitudeDegrees.text),
+            float(pos.LongitudeDegrees.text))
+            for pos in self.root.xpath('//ns:Trackpoint/ns:Position', namespaces={'ns': namespace})]
+
     def time_values(self):
         return [x.text for x in self.root.xpath('//ns:Time', namespaces={'ns': namespace})]
 

--- a/tests/test_tcxparser.py
+++ b/tests/test_tcxparser.py
@@ -90,6 +90,7 @@ class TestParseTCX(TestCase):
         self.assertAlmostEqual(values[-1][1], -79.0930143837)
 
     def test_distance_values_are_correct(self):
+        self.assertAlmostEqual(self.tcx.distance_values()[0], 0.0)
         self.assertAlmostEqual(self.tcx.distance_values()[-1], 4686.31103516)
 
 

--- a/tests/test_tcxparser.py
+++ b/tests/test_tcxparser.py
@@ -36,6 +36,9 @@ class TestParseTCX(TestCase):
     def test_activity_type_is_correct(self):
         self.assertEqual(self.tcx.activity_type, 'running')
 
+    def test_started_at_is_correct(self):
+        self.assertEqual(self.tcx.started_at, '2012-12-26T21:29:53Z')
+
     def test_completion_time_is_correct(self):
         self.assertEqual(self.tcx.completed_at, '2012-12-26T22:03:05Z')
 

--- a/tests/test_tcxparser.py
+++ b/tests/test_tcxparser.py
@@ -81,6 +81,11 @@ class TestParseTCX(TestCase):
     def test_activity_notes_is_correct(self):
         self.assertEqual(self.tcx.activity_notes, 'Aerobics')
 
+    def test_position_values_are_correct(self):
+        values = self.tcx.position_values()
+        self.assertAlmostEqual(values[-1][0], 35.9519544616)
+        self.assertAlmostEqual(values[-1][1], -79.0930143837)
+
 
 class BugTest(TestCase):
 

--- a/tests/test_tcxparser.py
+++ b/tests/test_tcxparser.py
@@ -86,6 +86,9 @@ class TestParseTCX(TestCase):
         self.assertAlmostEqual(values[-1][0], 35.9519544616)
         self.assertAlmostEqual(values[-1][1], -79.0930143837)
 
+    def test_distance_values_are_correct(self):
+        self.assertAlmostEqual(self.tcx.distance_values()[-1], 4686.31103516)
+
 
 class BugTest(TestCase):
 


### PR DESCRIPTION
If you want to draw your track on a map or plot distance vs. altitude, `distance_values` and `position_values` are necessary. I am also adding `started_at` for completeness as for some people (me?), this might be more relevant than `completed_at`.

Hope that this helps to improve your lib. Please consider whether the position format as (lat, lon) tuple is suitable.