### PR TITLE
Use the underscore name 'description_file'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [flake8]
 exclude = .tox


### PR DESCRIPTION
Fixed in this PR: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead...