### PR TITLE
Add badge for Fedora python-tcxparser package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ python-tcxparser
    :target: https://pyup.io/repos/github/vkurup/python-tcxparser/
    :alt: Requirement Updates
 
+.. image:: https://img.shields.io/fedora/v/python3-tcxparser?color=blue&label=Fedora%20Linux&logo=fedora
+   :target: https://src.fedoraproject.org/rpms/python-sport-activities-features
+   :alt: Fedora package
+
 .. |master-status| image::
     https://github.com/vkurup/python-tcxparser/workflows/lint-test/badge.svg?branch=master
     :alt: Build Status

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ python-tcxparser
    :alt: Requirement Updates
 
 .. image:: https://img.shields.io/fedora/v/python3-tcxparser?color=blue&label=Fedora%20Linux&logo=fedora
-   :target: https://src.fedoraproject.org/rpms/python-sport-activities-features
+   :target: https://src.fedoraproject.org/rpms/python-tcxparser
    :alt: Fedora package
 
 .. |master-status| image::


### PR DESCRIPTION
I am maintainer of this package for Fedora ecosystem. It can also be installed using following command: **dnf install python3-tcxparser**

Thus, I suggest @vkurup to add this badge which shows the recent version in Fedora package repository.